### PR TITLE
Fixes back btn issue

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -180,12 +180,15 @@ function locationHashChanged() {
         loadCartApp();
         showCartSlider()
     }
-    else if(!window.location.hash){
+    else if(window.location.hash == '#/' || window.location.hash == '') {
         closeCart();
-    } else if(window.location.hash == '#/' || window.location.hash == '') {
-        closeCart();
+        var variantpop= document.querySelector('#variation-selection-popup')
+        if(variantpop.classList.contains("show-modal")) {
+            variantpop.click()
+        }
     }
 }
+
 
 
 function closeCart(){


### PR DESCRIPTION
fixes When I click add to cart then select variant pop up opens up. Now on android, the natural way to close a pop up is to press back. This closes the site and takes you back to where you came to the site from. https://github.com/ajency/greengrainbowl/issues/235